### PR TITLE
Fixing bugs in qoqo_qasm

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -8,19 +8,19 @@ on:
 
 jobs:
 
-  deploy_cratesio:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        default: true
-    - name: setup cargo
-      run: |
-        cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
-        cargo publish --manifest-path=roqoqo-qasm/Cargo.toml
+  # deploy_cratesio:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: actions-rs/toolchain@v1
+  #     with:
+  #       profile: minimal
+  #       toolchain: stable
+  #       default: true
+  #   - name: setup cargo
+  #     run: |
+  #       cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
+  #       cargo publish --manifest-path=roqoqo-qasm/Cargo.toml
   deploy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -8,19 +8,20 @@ on:
 
 jobs:
 
-  # deploy_cratesio:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: actions-rs/toolchain@v1
-  #     with:
-  #       profile: minimal
-  #       toolchain: stable
-  #       default: true
-  #   - name: setup cargo
-  #     run: |
-  #       cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
-  #       cargo publish --manifest-path=roqoqo-qasm/Cargo.toml
+  deploy_cratesio:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        default: true
+    - name: setup cargo
+      run: |
+        cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
+        cargo publish --manifest-path=roqoqo-qasm/Cargo.toml
+
   deploy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Test with pytest
         run: |
           pip install pytest
+          pip install -r ./qoqo_qasm/tests/requirements.txt
           pip install -e ./qoqo_qasm/
           pytest --cov=qoqo_qasm --cov-fail-under=80
       - name: Lint with flake8

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ Cargo.lock
 target/*
 qoqo_qasm/target/*
 roqoqo-qasm/target/*
-*__pycache__/*
+*__pycache__*
 .mypy_cache*
 *.egg-info*
 *.qasm

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ roqoqo-qasm/target/*
 coverage.lcov
 coveragehtml/*
 *.pytest_cache*
+*.vscode*

--- a/qoqo_qasm/Cargo.toml
+++ b/qoqo_qasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo_qasm"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2018"
 

--- a/qoqo_qasm/qoqo_qasm/__version__.py
+++ b/qoqo_qasm/qoqo_qasm/__version__.py
@@ -10,4 +10,4 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
-__version__ = 'v0.3.2'
+__version__ = 'v0.3.3'

--- a/qoqo_qasm/qoqo_qasm/__version__.py
+++ b/qoqo_qasm/qoqo_qasm/__version__.py
@@ -10,4 +10,4 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
-__version__ = 'v0.3.1'
+__version__ = 'v0.3.2'

--- a/qoqo_qasm/qoqo_qasm/backend/qasm_backend.py
+++ b/qoqo_qasm/qoqo_qasm/backend/qasm_backend.py
@@ -77,7 +77,7 @@ class QasmBackend(object):
                     filename))
         output_lines = list()
         output_lines.append('OPENQASM 2.0;\n')
-        output_lines.append('include "qelib.inc";\n\n')
+        output_lines.append('include "qelib1.inc";\n\n')
 
         qasm_qubit_names: Dict[int, str] = dict()
         for ci in range(self.number_qubits):

--- a/qoqo_qasm/qoqo_qasm/interface/qasm_interface.py
+++ b/qoqo_qasm/qoqo_qasm/interface/qasm_interface.py
@@ -96,8 +96,9 @@ def qasm_call_circuit(
                 append_operation = qasm_call_operation(op,
                                                        number_qubits,
                                                        qubit_names)
-                # Exclude final ; for PragmaRepeatedMeasurement because it can produce multi-line statement
-                if  "PragmaRepeatedMeasurement" in tags:
+                # Exclude final ; for PragmaRepeatedMeasurement
+                # because it can produce multi-line statement
+                if "PragmaRepeatedMeasurement" in tags:
                     lines.append(append_operation)
                 elif append_operation is not None:
                     lines.append(append_operation + ';')
@@ -270,7 +271,7 @@ def _execute_PragmaRepeatedMeasurement(
                                            key)
     elif qubit_names is None and mapping_dictionary is not None:
         meas = ''
-        for j in range(max(mapping_dictionary.keys())+1):
+        for j in range(max(mapping_dictionary.keys()) + 1):
             meas += 'measure' + ' q[{}]'.format(mapping_dictionary[j])
             meas += ' -> {}[{}];\n'.format(operation.readout(),
                                            j)

--- a/qoqo_qasm/qoqo_qasm/interface/qasm_interface.py
+++ b/qoqo_qasm/qoqo_qasm/interface/qasm_interface.py
@@ -59,7 +59,7 @@ def qasm_call_circuit(
                 append_operation = qasm_call_operation(op,
                                                        number_qubits,
                                                        qubit_names)
-                if op.is_output():
+                if append_operation is not None:
                     lines.append(append_operation + ';')
             else:
                 if 'RotateX' in tags or 'RotateY' in tags or 'RotateZ' in tags:
@@ -90,13 +90,16 @@ def qasm_call_circuit(
                 append_operation = qasm_call_operation(op,
                                                        number_qubits,
                                                        qubit_names)
-                if op.is_output():
+                if append_operation is not None:
                     lines.append(append_operation + ';')
             else:
                 append_operation = qasm_call_operation(op,
                                                        number_qubits,
                                                        qubit_names)
-                if append_operation is not None:
+                # Exclude final ; for PragmaRepeatedMeasurement because it can produce multi-line statement
+                if  "PragmaRepeatedMeasurement" in tags:
+                    lines.append(append_operation)
+                elif append_operation is not None:
                     lines.append(append_operation + ';')
 
     return lines, symbolic_hash_lib
@@ -252,14 +255,27 @@ def _execute_PragmaRepeatedMeasurement(
         operation: Any,
         qubit_names: Optional[Dict[int, str]] = None,) -> str:
     operation = cast(ops.PragmaRepeatedMeasurement, operation)
-    if qubit_names is not None:
+    mapping_dictionary = operation.qubit_mapping()
+    if qubit_names is not None and mapping_dictionary is not None:
         meas = ''
-        for key, val in qubit_names.items():
-            meas += 'measure' + ' q[{}]'.format(key)
-            meas += ' -> {}[{}]\n'.format(operation.readout(),
-                                          val)
+        for key in qubit_names.keys():
+            meas += 'measure' + ' {}'.format(qubit_names[mapping_dictionary[key]])
+            meas += ' -> {}[{}];\n'.format(operation.readout(),
+                                           key)
+    elif qubit_names is not None and mapping_dictionary is None:
+        meas = ''
+        for key in qubit_names.keys():
+            meas += 'measure' + ' {}'.format(qubit_names[key])
+            meas += ' -> {}[{}];\n'.format(operation.readout(),
+                                           key)
+    elif qubit_names is None and mapping_dictionary is not None:
+        meas = ''
+        for j in range(max(mapping_dictionary.keys())+1):
+            meas += 'measure' + ' q[{}]'.format(mapping_dictionary[j])
+            meas += ' -> {}[{}];\n'.format(operation.readout(),
+                                           j)
     else:
         meas = 'measure'
         meas += ' q'
-        meas += ' -> {}'.format(operation.readout())
+        meas += ' -> {};\n'.format(operation.readout())
     return meas

--- a/qoqo_qasm/setup.py
+++ b/qoqo_qasm/setup.py
@@ -35,7 +35,7 @@ authors = 'HQS Quantum Simulations'
 
 
 setup(name='qoqo_qasm',
-      description='Quantum Computing Base Package',
+      description='qoqo quantum computing package qasm backend',
       version=__version__,
       long_description=readme,
       packages=find_packages(exclude=('docs')),

--- a/qoqo_qasm/tests/acceptance/test_acceptance.py
+++ b/qoqo_qasm/tests/acceptance/test_acceptance.py
@@ -1,0 +1,58 @@
+"""Test qoqo QASM acceptance"""
+# Copyright © 2019-2021 HQS Quantum Simulations GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+import pytest
+import sys
+import numpy as np
+import numpy.testing as npt
+from typing import Tuple, Any
+from qoqo import operations as ops
+from qoqo import Circuit
+from qoqo_qasm import qasm_call_operation
+from qoqo_qasm import QasmBackend
+from qiskit import QuantumCircuit
+
+
+def test_acceptance_with_qiskit():
+    """Test gate operations with QASM interface"""
+    circuit = Circuit()
+
+    circuit += ops.RotateX(0, -np.pi)
+    circuit += ops.RotateY(0, -np.pi)
+    circuit += ops.RotateZ(0, -np.pi)
+    circuit += ops.CNOT(0, 1)
+    circuit += ops.Hadamard(0)
+    circuit += ops.PauliX(0)
+    circuit += ops.PauliY(0)
+    circuit += ops.PauliZ(0)
+    circuit += ops.SGate(0)
+    circuit += ops.TGate(0)
+    circuit += ops.SqrtPauliX(0)
+    circuit += ops.MolmerSorensenXX(0, 1)
+    circuit += ops.ControlledPauliY(0, 1)
+    circuit += ops.ControlledPauliZ(0, 1)
+    circuit += ops.SingleQubitGate(0, 1, 0, 1, 0, 1.0)
+    circuit += ops.PragmaRepeatedMeasurement('ro', None, 1)
+    circuit += ops.MeasureQubit(0, 'ro', 0)
+    circuit += ops.DefinitionFloat(name='rof', length=1, is_output=True)
+    circuit += ops.DefinitionBit(name='ro', length=2, is_output=True)
+    circuit += ops.DefinitionComplex(name='roc', length=1, is_output=True)
+    circuit += ops.InputSymbolic('other', 0)
+    circuit += ops.PragmaSetNumberOfMeasurements(20, 'ro')
+
+    backend = QasmBackend(number_qubits=2)
+    backend.run_circuit(circuit=circuit, overwrite=True)
+
+    q_circuit = QuantumCircuit.from_qasm_file("default_qasm_backend_output.qasm")
+
+if __name__ == '__main__':
+    pytest.main(sys.argv)

--- a/qoqo_qasm/tests/interface/test_qasm_interface.py
+++ b/qoqo_qasm/tests/interface/test_qasm_interface.py
@@ -35,7 +35,9 @@ from qoqo_qasm import qasm_call_operation
     (ops.ControlledPauliY(0, 1), 'cy q[0],q[1]'),
     (ops.ControlledPauliZ(0, 1), 'cz q[0],q[1]'),
     (ops.SingleQubitGate(0, 1, 0, 1, 0, 1.0), 'u3(0.0,0.0,-0.0) q[0]'),
-    (ops.PragmaRepeatedMeasurement('ro', {0: 0, 1: 1}, 1), 'measure q -> ro'),
+    (ops.PragmaRepeatedMeasurement('ro', None, 1), 'measure q -> ro;\n'),
+    (ops.PragmaRepeatedMeasurement('ro', {0: 1, 1: 0}, 1),
+     'measure q[1] -> ro[0];\nmeasure q[0] -> ro[1];\n'),
     (ops.MeasureQubit(0, 'ro', 0), 'measure q[0] -> ro[0]'),
     (ops.DefinitionFloat(name='ro', length=1, is_output=True), 'creg ro[1]'),
     (ops.DefinitionUsize(name='ro', length=1, is_output=True), 'creg ro[1]'),
@@ -54,6 +56,44 @@ def test_gate_translation(gate: Tuple[Any, str]):
     else:
         npt.assert_string_equal(qasm_operation, gate[1])
 
+
+@pytest.mark.parametrize("gate", [
+    (ops.RotateX(0, -np.pi), 'rx(-3.141592653589793) s[1]'),
+    (ops.RotateY(0, -np.pi), 'ry(-3.141592653589793) s[1]'),
+    (ops.RotateZ(0, -np.pi), 'rz(-3.141592653589793) s[1]'),
+    (ops.CNOT(0, 1), 'cx s[1],s[0]'),
+    (ops.Hadamard(0), 'h s[1]'),
+    (ops.PauliX(0), 'x s[1]'),
+    (ops.PauliY(0), 'y s[1]'),
+    (ops.PauliZ(0), 'z s[1]'),
+    (ops.SGate(0), 's s[1]'),
+    (ops.TGate(0), 't s[1]'),
+    (ops.SqrtPauliX(0), 'rx(1.5707963267948966) s[1]'),
+    (ops.MolmerSorensenXX(0, 1), 'rxx(pi/2) s[1],s[0]'),
+    (ops.ControlledPauliY(0, 1), 'cy s[1],s[0]'),
+    (ops.ControlledPauliZ(0, 1), 'cz s[1],s[0]'),
+    (ops.SingleQubitGate(0, 1, 0, 1, 0, 1.0), 'u3(0.0,0.0,-0.0) s[1]'),
+    (ops.PragmaRepeatedMeasurement('ro', {0: 0, 1: 1}, 1), 'measure s[1] -> ro[0];\nmeasure s[0] -> ro[1];\n'),
+    (ops.PragmaRepeatedMeasurement('ro', {0: 1, 1: 0}, 1),
+     'measure s[0] -> ro[0];\nmeasure s[1] -> ro[1];\n'),
+    (ops.MeasureQubit(0, 'ro', 0), 'measure s[1] -> ro[0]'),
+    (ops.DefinitionFloat(name='ro', length=1, is_output=True), 'creg ro[1]'),
+    (ops.DefinitionUsize(name='ro', length=1, is_output=True), 'creg ro[1]'),
+    (ops.DefinitionBit(name='ro', length=1, is_output=True), 'creg ro[1]'),
+    (ops.DefinitionComplex(name='ro', length=1, is_output=True), 'creg ro[1]'),
+    (ops.InputSymbolic('other', 0), None),
+    (ops.PragmaSetNumberOfMeasurements(20, 'ro'), None)
+])
+def test_gate_translation_qubit_names(gate: Tuple[Any, str]):
+    """Test gate operations with QASM interface"""
+    qasm_operation = qasm_call_operation(operation=gate[0],
+                                         number_qubits=2,
+                                         qubit_names={0: "s[1]", 1: "s[0]"},)
+
+    if gate[1] is None:
+        assert qasm_operation is None
+    else:
+        npt.assert_string_equal(qasm_operation, gate[1])
 
 
 if __name__ == '__main__':

--- a/qoqo_qasm/tests/requirements.txt
+++ b/qoqo_qasm/tests/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+qiskit-terra

--- a/roqoqo-qasm/Cargo.toml
+++ b/roqoqo-qasm/Cargo.toml
@@ -19,7 +19,6 @@ doctest = false
 [dependencies]
 roqoqo = {version="0.5", features=["serialize"]}
 qoqo_calculator = {version="0.3"}
-roqoqo-test = {version="0.5"}
 test-case = "1.1.0"
 
 

--- a/roqoqo-qasm/Cargo.toml
+++ b/roqoqo-qasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo-qasm"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 license = "Apache-2.0"
 edition = "2018"
@@ -17,9 +17,9 @@ doctest = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-roqoqo = {version="0.2", features=["serialize"]}
-qoqo_calculator = {version="0.2"}
-roqoqo-test = {version="0.1"}
+roqoqo = {version="0.5", features=["serialize"]}
+qoqo_calculator = {version="0.3"}
+roqoqo-test = {version="0.5"}
 test-case = "1.1.0"
 
 

--- a/roqoqo-qasm/src/backend.rs
+++ b/roqoqo-qasm/src/backend.rs
@@ -16,25 +16,29 @@ use roqoqo::{Circuit, RoqoqoBackendError};
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
+use std::usize;
 
 /// QASM backend to qoqo
 ///
-/// This backend to qoqo produces QASM output which can be exported.
+/// This backend to roqoqo produces QASM output which can be exported.
 ///
-/// This backend takes a qoqo circuit to be run on a certain device and returns a QASM file
-/// containing the translated circuit. The circuit itself is translated using the qoqo_qasm
+/// This backend takes a roqoqo circuit and returns a QASM String or writes a QASM file
+/// containing the translated circuit. The circuit itself is translated using the roqoqo-qasm
 /// interface. In this backend, the initialization sets up the relevant parameters and the run
 /// function calls the QASM interface and writes the QASM file, which is saved to be used by the
 /// user on whatever platform they see fit. QASM input is widely supported on various quantum
 /// computing platforms.
 ///
-/// # Arguments
-///
-/// * `number_qubits` - The number of qubits in the Backend.
 ///
 #[derive(Debug, Clone, PartialEq)]
 pub struct Backend {
-    number_qubits: usize,
+    /// Name of the qubit_register assigned to the roqoqo qubits.
+    ///
+    /// roqoqo uses as unified address-space for qubits.
+    /// There are no separate quantum registers and all qubits are addressed with `usize` addresses.
+    /// When translating to QASM which uses explicitely declared qubit registers a name for the qubit
+    /// register needs to be chosen.
+    qubit_register_name: String,
 }
 
 impl Backend {
@@ -42,31 +46,71 @@ impl Backend {
     ///
     /// # Arguments
     ///
-    /// * `number_qubits` - The number of qubits in the backend.
+    /// * `qubit_register_name` - The number of qubits in the backend.
+    /// * ``
     ///
-    /// # Returns
-    ///
-    /// * `Backend` - The new instance of Backend with the specified inputs.
-    pub fn new(number_qubits: usize) -> Self {
-        Self { number_qubits }
+    pub fn new(qubit_register_name: Option<String>) -> Self {
+        match qubit_register_name {
+            None => Self {
+                qubit_register_name: "q".to_string(),
+            },
+            Some(s) => Self {
+                qubit_register_name: s,
+            },
+        }
     }
 }
 
-
 impl Backend {
-    /// Runs a circuit with the backend.
+    /// Translates an iterator over operations to a valid QASM string.
     ///
-    /// A circuit is passed to the roqoqo-qasm backend and executed.
-    /// During execution values are written to and read from classical registers
-    /// ([crate::registers::BitRegister], [crate::registers::FloatRegister] and [crate::registers::ComplexRegister]).
-    /// To produce sufficient statistics for evaluating expectationg values,
-    /// circuits have to be run multiple times.
-    /// The results of each repetition are concatenated in OutputRegisters
-    /// ([crate::registers::BitOutputRegister], [crate::registers::FloatOutputRegister] and [crate::registers::ComplexOutputRegister]).  
     ///
     /// # Arguments
     ///
-    /// * `circuit` - The circuit that is run on the backend.
+    /// * `circuit` - The iterator over [roqoqo::Operation] items that is translated
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(String)` - The valid QASM string
+    /// * `RoqoqoBackendError::OperationNotInBackend` - An operation is not available on the backend
+    pub fn circuit_iterator_to_qasm_str<'a>(
+        &self,
+        circuit: impl Iterator<Item = &'a Operation>,
+    ) -> Result<String, RoqoqoBackendError> {
+        let mut data: String = "".to_string();
+        let mut qasm_string = String::from("OPENQASM 2.0\ninclude \"qelib1.inc\";\n\n");
+
+        let mut number_qubits_required: usize = 0;
+        for op in circuit {
+            if let InvolvedQubits::Set(involved_qubits) = op.involved_qubits() {
+                number_qubits_required =
+                    number_qubits_required.max(match involved_qubits.iter().max() {
+                        None => 0,
+                        Some(n) => *n,
+                    })
+            }
+            data.push_str(&call_operation(op, &self.qubit_register_name)?);
+            data.push('\n');
+        }
+        qasm_string.push_str(
+            format!(
+                "qreg {}[{}];\n",
+                self.qubit_register_name,
+                number_qubits_required + 1
+            )
+            .as_str(),
+        );
+
+        qasm_string.push_str(data.as_str());
+
+        Ok(qasm_string)
+    }
+
+    /// Translates an iterator over operations to a QASM file.
+    ///
+    /// # Arguments
+    ///
+    /// * `circuit` - The iterator over [roqoqo::Operation] items that is translated
     /// * `folder_name` - The name of the folder that is prepended to all filenames in run function.
     /// * `filename` - The name of the file the QASM text is saved to.
     /// * `overwrite` - Whether to overwrite file if it already exists.
@@ -75,20 +119,14 @@ impl Backend {
     ///
     /// * `Ok(())` - The qasm file was correctly written
     /// * `RoqoqoBackendError::FileAlreadyExists` - The file at this location already exists
-    pub fn run_circuit_iterator<'a>(
+    pub fn circuit_iterator_to_qasm_file<'a>(
         &self,
         circuit: impl Iterator<Item = &'a Operation>,
         folder_name: String,
         filename: String,
         overwrite: bool,
     ) -> Result<(), RoqoqoBackendError> {
-        let mut data: String = String::from("OPENQASM 2.0\ninclude \"qelib1.inc\";\n\n");
-        for op in circuit {
-            if let Ok(x) = call_operation(op) {
-                data.push_str(&x);
-                data.push('\n');
-            }
-        }
+        let data: String = self.circuit_iterator_to_qasm_str(circuit)?;
 
         let mut path: String = folder_name;
         path.push_str(&filename);
@@ -105,34 +143,41 @@ impl Backend {
         Ok(())
     }
 
-    /// Runs a circuit with the backend.
-    ///
-    /// A circuit is passed to the backend and executed.
-    /// During execution values are written to and read from classical registers
-    /// ([crate::registers::BitRegister], [crate::registers::FloatRegister] and [crate::registers::ComplexRegister]).
-    /// To produce sufficient statistics for evaluating expectationg values,
-    /// circuits have to be run multiple times.
-    /// The results of each repetition are concatenated in OutputRegisters
-    /// ([crate::registers::BitOutputRegister], [crate::registers::FloatOutputRegister] and [crate::registers::ComplexOutputRegister]).  
+    /// Translates a Circuit to a valid QASM string.
     ///
     ///
     /// # Arguments
     ///
-    /// * `circuit` - The circuit that is run on the backend.
+    /// * `circuit` - The Circuit items that is translated
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(String)` - The valid QASM string
+    /// * `RoqoqoBackendError::OperationNotInBackend` - An operation is not available on the backend
+    pub fn circuit_to_qasm_str(&self, circuit: &Circuit) -> Result<String, RoqoqoBackendError> {
+        self.circuit_iterator_to_qasm_str(circuit.iter())
+    }
+
+    /// Translates a Circuit to a QASM file.
+    ///
+    /// # Arguments
+    ///
+    /// * `circuit` - The Circuit that is translated
     /// * `folder_name` - The name of the folder that is prepended to all filenames in run function.
     /// * `filename` - The name of the file the QASM text is saved to.
     /// * `overwrite` - Whether to overwrite file if it already exists.
     ///
     /// # Returns
     ///
-    /// `RegisterResult` - The output registers written by the evaluated circuits.
-    pub fn run_circuit(
+    /// * `Ok(())` - The qasm file was correctly written
+    /// * `RoqoqoBackendError::FileAlreadyExists` - The file at this location already exists
+    pub fn circuit_to_qasm_file(
         &self,
         circuit: &Circuit,
         folder_name: String,
         filename: String,
         overwrite: bool,
     ) -> Result<(), RoqoqoBackendError> {
-        self.run_circuit_iterator(circuit.iter(), folder_name, filename, overwrite)
+        self.circuit_iterator_to_qasm_file(circuit.iter(), folder_name, filename, overwrite)
     }
 }

--- a/roqoqo-qasm/src/backend.rs
+++ b/roqoqo-qasm/src/backend.rs
@@ -52,25 +52,7 @@ impl Backend {
     }
 }
 
-/// Trait for Backends that can evaluate measurements to expectation values.
-///
-/// # Example
-/// ```
-/// use roqoqo::{Circuit, backends::EvaluatingBackend, operations::*};
-/// use roqoqo_qasm::Backend;
-/// use std::collections::HashMap;
-///
-/// let backend = Backend::new(2_usize);
-/// let mut circuit = Circuit::new();
-/// circuit += DefinitionBit::new("ro".to_string(), 2, true);
-/// circuit += RotateX::new(0, std::f64::consts::FRAC_PI_2.into());
-/// circuit += PauliX::new(1);
-/// circuit += PragmaRepeatedMeasurement::new("ro".to_string(), None, 20);
-///
-/// let result = backend.run_circuit(&circuit, "".to_string(), "test".to_string(), true).unwrap();
-/// assert_eq!(result, ());
-/// ```
-///
+
 impl Backend {
     /// Runs a circuit with the backend.
     ///
@@ -100,7 +82,7 @@ impl Backend {
         filename: String,
         overwrite: bool,
     ) -> Result<(), RoqoqoBackendError> {
-        let mut data: String = String::from("OPENQASM 2.0\ninclude \"qelib.inc\";\n\n");
+        let mut data: String = String::from("OPENQASM 2.0\ninclude \"qelib1.inc\";\n\n");
         for op in circuit {
             if let Ok(x) = call_operation(op) {
                 data.push_str(&x);

--- a/roqoqo-qasm/tests/integration/backend.rs
+++ b/roqoqo-qasm/tests/integration/backend.rs
@@ -21,56 +21,71 @@ use std::fs;
 /// Test simple circuit with a Definition, a GateOperation and a PragmaOperation
 #[test]
 fn run_simple_circuit() {
-    let backend = Backend::new(2);
+    let backend = Backend::new(Some("qr".to_string()));
     let mut circuit = Circuit::new();
     circuit += DefinitionBit::new("ro".to_string(), 2, true);
     circuit += RotateX::new(0, std::f64::consts::FRAC_PI_2.into());
     circuit += PauliX::new(1);
     circuit += PragmaRepeatedMeasurement::new("ro".to_string(), None, 20);
     let _ = backend
-        .run_circuit(&circuit, "".to_string(), "test_simple".to_string(), true)
+        .circuit_to_qasm_file(
+            &circuit,
+            "/tmp/".to_string(),
+            "test_simple0".to_string(),
+            true,
+        )
         .unwrap();
 
-    let lines = String::from("OPENQASM 2.0\ninclude \"qelib1.inc\";\n\ncreg ro[2];\nrx(1.5707963267948966) q[0];\nx q[1];\nmeasure q -> ro;\n");
-    let extracted = fs::read_to_string("test_simple.qasm");
+    let lines = String::from("OPENQASM 2.0\ninclude \"qelib1.inc\";\n\nqreg qr[2];\ncreg ro[2];\nrx(1.5707963267948966) qr[0];\nx qr[1];\nmeasure qr -> ro;\n");
+    let extracted = fs::read_to_string("/tmp/test_simple0.qasm");
     assert_eq!(lines, extracted.unwrap());
 }
 
 /// Test simple circuit with a Definition, a GateOperation and a PragmaOperation
 #[test]
-fn run_simple_circuit_iterator() {
-    let backend = Backend::new(2);
+fn simple_circuit_iterator_to_file() {
+    let backend = Backend::new(None);
     let mut circuit = Circuit::new();
     circuit += DefinitionBit::new("ro".to_string(), 2, true);
     circuit += RotateX::new(0, std::f64::consts::FRAC_PI_2.into());
     circuit += PauliX::new(1);
     circuit += PragmaRepeatedMeasurement::new("ro".to_string(), None, 20);
     let _ = backend
-        .run_circuit_iterator(
+        .circuit_iterator_to_qasm_file(
             circuit.iter(),
-            "".to_string(),
-            "test_simple".to_string(),
+            "/tmp/".to_string(),
+            "test_simple1".to_string(),
             true,
         )
         .unwrap();
 
-    let lines = String::from("OPENQASM 2.0\ninclude \"qelib1.inc\";\n\ncreg ro[2];\nrx(1.5707963267948966) q[0];\nx q[1];\nmeasure q -> ro;\n");
-    let extracted = fs::read_to_string("test_simple.qasm");
+    let lines = String::from("OPENQASM 2.0\ninclude \"qelib1.inc\";\n\nqreg q[2];\ncreg ro[2];\nrx(1.5707963267948966) q[0];\nx q[1];\nmeasure q -> ro;\n");
+    let extracted = fs::read_to_string("/tmp/test_simple1.qasm");
     assert_eq!(lines, extracted.unwrap());
 }
 
 /// Test that backend returns error when running for a file that exists without overwrite
 #[test]
 fn run_error() {
-    let backend = Backend::new(2);
+    let backend = Backend::new(None);
     let mut circuit = Circuit::new();
     circuit += DefinitionBit::new("ro".to_string(), 2, true);
-    let _ = backend.run_circuit(&circuit, "".to_string(), "test_simple".to_string(), false);
-    let error = backend.run_circuit(&circuit, "".to_string(), "test_simple".to_string(), false);
+    let _ = backend.circuit_to_qasm_file(
+        &circuit,
+        "/tmp/".to_string(),
+        "test_simple".to_string(),
+        false,
+    );
+    let error = backend.circuit_to_qasm_file(
+        &circuit,
+        "/tmp/".to_string(),
+        "test_simple".to_string(),
+        false,
+    );
     assert_eq!(
         error,
         Err(RoqoqoBackendError::FileAlreadyExists {
-            path: "test_simple.qasm".to_string()
+            path: "/tmp/test_simple.qasm".to_string()
         })
     );
 }
@@ -78,17 +93,20 @@ fn run_error() {
 /// Test Debug, Clone and PartialEq for Backend
 #[test]
 fn test_debug_clone_partialeq() {
-    let backend = Backend::new(0);
+    let backend = Backend::new(Some("qtest".to_string()));
 
     // Test Debug trait
-    assert_eq!(format!("{:?}", backend), "Backend { number_qubits: 0 }");
+    assert_eq!(
+        format!("{:?}", backend),
+        "Backend { qubit_register_name: \"qtest\" }"
+    );
 
     // Test Clone trait
     assert_eq!(backend.clone(), backend);
 
     // PartialEq
-    let backend_0 = Backend::new(0);
-    let backend_2 = Backend::new(2);
+    let backend_0 = Backend::new(Some("qtest".to_string()));
+    let backend_2 = Backend::new(Some("q".to_string()));
 
     assert!(backend_0 == backend);
     assert!(backend == backend_0);

--- a/roqoqo-qasm/tests/integration/backend.rs
+++ b/roqoqo-qasm/tests/integration/backend.rs
@@ -31,7 +31,7 @@ fn run_simple_circuit() {
         .run_circuit(&circuit, "".to_string(), "test_simple".to_string(), true)
         .unwrap();
 
-    let lines = String::from("OPENQASM 2.0\ninclude \"qelib.inc\";\n\ncreg ro[2]\nrx(1.5707963267948966) q[0]\nx q[1]\nmeasure q -> ro\n");
+    let lines = String::from("OPENQASM 2.0\ninclude \"qelib1.inc\";\n\ncreg ro[2];\nrx(1.5707963267948966) q[0];\nx q[1];\nmeasure q -> ro;\n");
     let extracted = fs::read_to_string("test_simple.qasm");
     assert_eq!(lines, extracted.unwrap());
 }
@@ -54,7 +54,7 @@ fn run_simple_circuit_iterator() {
         )
         .unwrap();
 
-    let lines = String::from("OPENQASM 2.0\ninclude \"qelib.inc\";\n\ncreg ro[2]\nrx(1.5707963267948966) q[0]\nx q[1]\nmeasure q -> ro\n");
+    let lines = String::from("OPENQASM 2.0\ninclude \"qelib1.inc\";\n\ncreg ro[2];\nrx(1.5707963267948966) q[0];\nx q[1];\nmeasure q -> ro;\n");
     let extracted = fs::read_to_string("test_simple.qasm");
     assert_eq!(lines, extracted.unwrap());
 }

--- a/roqoqo-qasm/tests/integration/backend.rs
+++ b/roqoqo-qasm/tests/integration/backend.rs
@@ -16,8 +16,9 @@ use roqoqo::prelude::*;
 use roqoqo::{operations::*, Circuit};
 use roqoqo_qasm::Backend;
 // use roqoqo_test::prepare_monte_carlo_gate_test;
+use std::env::temp_dir;
 use std::fs;
-
+use std::path::Path;
 /// Test simple circuit with a Definition, a GateOperation and a PragmaOperation
 #[test]
 fn run_simple_circuit() {
@@ -30,14 +31,16 @@ fn run_simple_circuit() {
     let _ = backend
         .circuit_to_qasm_file(
             &circuit,
-            "/tmp/".to_string(),
-            "test_simple0".to_string(),
+            temp_dir().as_path(),
+            &Path::new("test_simple0"),
             true,
         )
         .unwrap();
 
     let lines = String::from("OPENQASM 2.0\ninclude \"qelib1.inc\";\n\nqreg qr[2];\ncreg ro[2];\nrx(1.5707963267948966) qr[0];\nx qr[1];\nmeasure qr -> ro;\n");
-    let extracted = fs::read_to_string("/tmp/test_simple0.qasm");
+    let read_in_path = temp_dir().join(Path::new("test_simple0.qasm"));
+    let extracted = fs::read_to_string(&read_in_path);
+    fs::remove_file(&read_in_path).unwrap();
     assert_eq!(lines, extracted.unwrap());
 }
 
@@ -53,14 +56,16 @@ fn simple_circuit_iterator_to_file() {
     let _ = backend
         .circuit_iterator_to_qasm_file(
             circuit.iter(),
-            "/tmp/".to_string(),
-            "test_simple1".to_string(),
+            temp_dir().as_path(),
+            Path::new("test_simple1"),
             true,
         )
         .unwrap();
 
     let lines = String::from("OPENQASM 2.0\ninclude \"qelib1.inc\";\n\nqreg q[2];\ncreg ro[2];\nrx(1.5707963267948966) q[0];\nx q[1];\nmeasure q -> ro;\n");
-    let extracted = fs::read_to_string("/tmp/test_simple1.qasm");
+    let read_in_path = temp_dir().join(Path::new("test_simple1.qasm"));
+    let extracted = fs::read_to_string(&read_in_path);
+    fs::remove_file(&read_in_path).unwrap();
     assert_eq!(lines, extracted.unwrap());
 }
 
@@ -72,20 +77,21 @@ fn run_error() {
     circuit += DefinitionBit::new("ro".to_string(), 2, true);
     let _ = backend.circuit_to_qasm_file(
         &circuit,
-        "/tmp/".to_string(),
-        "test_simple".to_string(),
+        temp_dir().as_path(),
+        Path::new("test_simple"),
         false,
     );
     let error = backend.circuit_to_qasm_file(
         &circuit,
-        "/tmp/".to_string(),
-        "test_simple".to_string(),
+        temp_dir().as_path(),
+        Path::new("test_simple"),
         false,
     );
+    let read_in_path = temp_dir().join(Path::new("test_simple.qasm"));
     assert_eq!(
         error,
         Err(RoqoqoBackendError::FileAlreadyExists {
-            path: "/tmp/test_simple.qasm".to_string()
+            path: read_in_path.to_str().unwrap().to_string()
         })
     );
 }

--- a/roqoqo-qasm/tests/integration/interface.rs
+++ b/roqoqo-qasm/tests/integration/interface.rs
@@ -22,27 +22,27 @@ use std::f64::consts::PI;
 use test_case::test_case;
 
 /// Test that all operations return the correct String
-#[test_case(Operation::from(PauliX::new(0)), "x q[0]"; "PauliX")]
-#[test_case(Operation::from(PauliY::new(0)), "y q[0]"; "PauliY")]
-#[test_case(Operation::from(PauliZ::new(0)), "z q[0]"; "PauliZ")]
-#[test_case(Operation::from(Hadamard::new(0)), "h q[0]"; "Hadamard")]
-#[test_case(Operation::from(SGate::new(0)), "s q[0]"; "SGate")]
-#[test_case(Operation::from(TGate::new(0)), "t q[0]"; "TGate")]
-#[test_case(Operation::from(RotateX::new(0, CalculatorFloat::from(-PI))), "rx(-3.141592653589793) q[0]"; "RotateX")]
-#[test_case(Operation::from(RotateY::new(0, CalculatorFloat::from(-PI))), "ry(-3.141592653589793) q[0]"; "RotateY")]
-#[test_case(Operation::from(RotateZ::new(0, CalculatorFloat::from(-PI))), "rz(-3.141592653589793) q[0]"; "RotateZ")]
-#[test_case(Operation::from(SqrtPauliX::new(0)), "rx(pi/2) q[0]"; "SqrtPauliX")]
-#[test_case(Operation::from(MolmerSorensenXX::new(0, 1)), "rxx(pi/2) q[0],q[1]"; "MolmerSorensenXX")]
-#[test_case(Operation::from(CNOT::new(0, 1)), "cx q[0],q[1]"; "CNOT")]
-#[test_case(Operation::from(ControlledPauliY::new(0, 1)), "cy q[0],q[1]"; "ControlledPauliY")]
-#[test_case(Operation::from(ControlledPauliZ::new(0, 1)), "cz q[0],q[1]"; "ControlledPauliZ")]
+#[test_case(Operation::from(PauliX::new(0)), "x q[0];"; "PauliX")]
+#[test_case(Operation::from(PauliY::new(0)), "y q[0];"; "PauliY")]
+#[test_case(Operation::from(PauliZ::new(0)), "z q[0];"; "PauliZ")]
+#[test_case(Operation::from(Hadamard::new(0)), "h q[0];"; "Hadamard")]
+#[test_case(Operation::from(SGate::new(0)), "s q[0];"; "SGate")]
+#[test_case(Operation::from(TGate::new(0)), "t q[0];"; "TGate")]
+#[test_case(Operation::from(RotateX::new(0, CalculatorFloat::from(-PI))), "rx(-3.141592653589793) q[0];"; "RotateX")]
+#[test_case(Operation::from(RotateY::new(0, CalculatorFloat::from(-PI))), "ry(-3.141592653589793) q[0];"; "RotateY")]
+#[test_case(Operation::from(RotateZ::new(0, CalculatorFloat::from(-PI))), "rz(-3.141592653589793) q[0];"; "RotateZ")]
+#[test_case(Operation::from(SqrtPauliX::new(0)), "rx(pi/2) q[0];"; "SqrtPauliX")]
+#[test_case(Operation::from(MolmerSorensenXX::new(0, 1)), "rxx(pi/2) q[0],q[1];"; "MolmerSorensenXX")]
+#[test_case(Operation::from(CNOT::new(0, 1)), "cx q[0],q[1];"; "CNOT")]
+#[test_case(Operation::from(ControlledPauliY::new(0, 1)), "cy q[0],q[1];"; "ControlledPauliY")]
+#[test_case(Operation::from(ControlledPauliZ::new(0, 1)), "cz q[0],q[1];"; "ControlledPauliZ")]
 // #[test_case(Operation::from(SingleQubitGate::new(0, CalculatorFloat::from(1.0), CalculatorFloat::from(0.0), CalculatorFloat::from(0.0), CalculatorFloat::from(0.0), CalculatorFloat::from(0.0))), "u3(0.000000000000000,0.000000000000000,0.000000000000000) q[0]"; "SingleQubitGate")]
-#[test_case(Operation::from(PragmaRepeatedMeasurement::new("ro".to_string(), Some(HashMap::new()), 1)), "measure q -> ro"; "PragmaRepeatedMeasurement")]
-#[test_case(Operation::from(MeasureQubit::new(0, "ro".to_string(), 0)), "measure q[0] -> ro[0]"; "MeasureQubit")]
-#[test_case(Operation::from(DefinitionFloat::new("ro".to_string(), 1, true)), "creg ro[1]"; "DefinitionFloat")]
-#[test_case(Operation::from(DefinitionUsize::new("ro".to_string(), 1, true)), "creg ro[1]"; "DefinitionUsize")]
-#[test_case(Operation::from(DefinitionBit::new("ro".to_string(), 1, true)), "creg ro[1]"; "DefinitionBit")]
-#[test_case(Operation::from(DefinitionComplex::new("ro".to_string(), 1, true)), "creg ro[1]"; "DefinitionComplex")]
+#[test_case(Operation::from(PragmaRepeatedMeasurement::new("ro".to_string(), Some(HashMap::new()), 1)), "measure q -> ro;"; "PragmaRepeatedMeasurement")]
+#[test_case(Operation::from(MeasureQubit::new(0, "ro".to_string(), 0)), "measure q[0] -> ro[0];"; "MeasureQubit")]
+#[test_case(Operation::from(DefinitionFloat::new("ro".to_string(), 1, true)), "creg ro[1];"; "DefinitionFloat")]
+#[test_case(Operation::from(DefinitionUsize::new("ro".to_string(), 1, true)), "creg ro[1];"; "DefinitionUsize")]
+#[test_case(Operation::from(DefinitionBit::new("ro".to_string(), 1, true)), "creg ro[1];"; "DefinitionBit")]
+#[test_case(Operation::from(DefinitionComplex::new("ro".to_string(), 1, true)), "creg ro[1];"; "DefinitionComplex")]
 #[test_case(Operation::from(InputSymbolic::new("other".to_string(), 0.0)), ""; "InputSymbolic")]
 #[test_case(Operation::from(PragmaSetNumberOfMeasurements::new(20, "ro".to_string())), ""; "PragmaSetNumberOfMeasurements")]
 fn test_call_operation(operation: Operation, converted: &str) {
@@ -71,9 +71,9 @@ fn test_call_circuit() {
     circuit += MeasureQubit::new(0, "ro".to_string(), 0);
 
     let mut qasm_circ: Vec<String> = Vec::new();
-    qasm_circ.push("creg ro[1]".to_string());
-    qasm_circ.push("x q[0]".to_string());
-    qasm_circ.push("measure q[0] -> ro[0]".to_string());
+    qasm_circ.push("creg ro[1];".to_string());
+    qasm_circ.push("x q[0];".to_string());
+    qasm_circ.push("measure q[0] -> ro[0];".to_string());
 
     assert_eq!(call_circuit(&circuit).unwrap(), qasm_circ);
 }

--- a/roqoqo-qasm/tests/integration/interface.rs
+++ b/roqoqo-qasm/tests/integration/interface.rs
@@ -46,7 +46,6 @@ fn tmp_create_map() -> HashMap<usize, usize> {
 #[test_case(Operation::from(ControlledPauliZ::new(0, 1)), "cz q[0],q[1];"; "ControlledPauliZ")]
 // #[test_case(Operation::from(SingleQubitGate::new(0, CalculatorFloat::from(1.0), CalculatorFloat::from(0.0), CalculatorFloat::from(0.0), CalculatorFloat::from(0.0), CalculatorFloat::from(0.0))), "u3(0.000000000000000,0.000000000000000,0.000000000000000) q[0]"; "SingleQubitGate")]
 #[test_case(Operation::from(PragmaRepeatedMeasurement::new("ro".to_string(), None, 1)), "measure q -> ro;"; "PragmaRepeatedMeasurement")]
-#[test_case(Operation::from(PragmaRepeatedMeasurement::new("ro".to_string(), Some(tmp_create_map()), 1)), "measure q[1] -> ro[0];\nmeasure q[0] -> ro[1];\n"; "PragmaRepeatedMeasurement_Mapping")]
 #[test_case(Operation::from(MeasureQubit::new(0, "ro".to_string(), 0)), "measure q[0] -> ro[0];"; "MeasureQubit")]
 #[test_case(Operation::from(DefinitionFloat::new("ro".to_string(), 1, true)), "creg ro[1];"; "DefinitionFloat")]
 #[test_case(Operation::from(DefinitionUsize::new("ro".to_string(), 1, true)), "creg ro[1];"; "DefinitionUsize")]
@@ -59,6 +58,18 @@ fn test_call_operation(operation: Operation, converted: &str) {
         call_operation(&operation, "q").unwrap(),
         converted.to_string()
     )
+}
+
+#[test]
+fn test_pragma_repeated_operation() {
+    let operation = Operation::from(PragmaRepeatedMeasurement::new(
+        "ro".to_string(),
+        Some(tmp_create_map()),
+        1,
+    ));
+    let qasm_string = call_operation(&operation, "q").unwrap();
+    assert!(qasm_string.contains("measure q[0] -> ro[1];\n"));
+    assert!(qasm_string.contains("measure q[1] -> ro[0];\n"));
 }
 
 /// Test that non-included gates return an error


### PR DESCRIPTION
* Fix bug producing wrong indices and `;` delimiters when using PragmaRepeatedMeasurement with qubit_names
* Fix wrong name of qasm import lib
* Add additional acceptance test to avoid this type of bug in the future