### PR TITLE
QASM Import Gate Definition Skip

### DIFF
--- a/.github/workflows/hqs-ci-test-rust-pyo3.yml
+++ b/.github/workflows/hqs-ci-test-rust-pyo3.yml
@@ -24,8 +24,8 @@ jobs:
     uses: HQSquantumsimulations/reusable_workflows/.github/workflows/reusable_build_tests_rust_pyo3.yml@main
     with: 
       # Run tests also on windows runners
-      windows: false
+      windows: true
       # Run tests also on macos runners
-      macos: false
+      macos: true
       py_interface_folder: "qoqo_qasm"
       has_python_tests: true

--- a/.github/workflows/hqs-ci-test-rust-pyo3.yml
+++ b/.github/workflows/hqs-ci-test-rust-pyo3.yml
@@ -26,6 +26,6 @@ jobs:
       # Run tests also on windows runners
       windows: true
       # Run tests also on macos runners
-      macos: true
+      macos: false
       py_interface_folder: "qoqo_qasm"
       has_python_tests: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This changelog track changes to the qoqo qasm project starting at version 0.5.0
 
+### 0.9.4
+
+* Updated to qoqo 1.9
+* Updated parsing feature to skip QASM gate definitions
+
 ### 0.9.3
 
 * Updated to qoqo 1.8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -157,9 +157,9 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "inventory"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0508c56cfe9bfd5dfeb0c22ab9a6abfda2f27bdca422132e494266351ed8d83c"
+checksum = "c8573b2b1fb643a372c73b23f4da5f888677feef3305146d68a539250a9bccc7"
 
 [[package]]
 name = "itertools"
@@ -178,9 +178,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libm"
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
@@ -357,9 +357,9 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pest"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
+checksum = "1f200d8d83c44a45b21764d1916299752ca035d15ecd46faca3e9a2a2bf6ad06"
 dependencies = [
  "memchr",
  "thiserror",
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d78524685f5ef2a3b3bd1cafbc9fcabb036253d9b1463e726a91cd16e2dfc2"
+checksum = "bcd6ab1236bbdb3a49027e920e693192ebfe8913f6d60e294de57463a493cfde"
 dependencies = [
  "pest",
  "pest_generator",
@@ -378,22 +378,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bd1206e71118b5356dae5ddc61c8b11e28b09ef6a31acbd15ea48a28e0c227"
+checksum = "2a31940305ffc96863a735bef7c7994a00b325a7138fdbc5bda0f1a0476d3275"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c747191d4ad9e4a4ab9c8798f1e82a39affe7ef9648390b7e5548d18e099de6"
+checksum = "a7ff62f5259e53b78d1af898941cdcdccfae7385cf7d793a6e55de5d05bb4b7d"
 dependencies = [
  "once_cell",
  "pest",
@@ -420,18 +420,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e8453b658fe480c3e70c8ed4e3d3ec33eb74988bd186561b0cc66b85c3bc4b"
+checksum = "9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -448,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96fe70b176a89cff78f2fa7b3c930081e163d5379b4dcdf993e3ae29ca662e5"
+checksum = "07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214929900fd25e6604661ed9cf349727c8920d47deff196c4e28165a6ef2a96b"
+checksum = "dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -468,33 +468,33 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac53072f717aa1bfa4db832b39de8c875b7c7af4f4a6fe93cdbf9264cf8383b"
+checksum = "05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774b5a8282bd4f25f803b1f0d945120be959a36c72e08e7cd031c792fdfd424"
+checksum = "0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "qoqo"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7682cb26d77a31aadc31ecf3655888a52a2658e7f772998d8a8d541e6ffbc97"
+checksum = "b60a2dcf07ce42e2cb1d967db05ef50be9e6f7c4ceeba8540b51fd61aa076921"
 dependencies = [
  "bincode",
  "ndarray",
@@ -513,19 +513,19 @@ dependencies = [
  "serde_json",
  "struqture",
  "struqture-py",
- "syn 2.0.40",
+ "syn 2.0.48",
  "thiserror",
 ]
 
 [[package]]
 name = "qoqo-macros"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6a7fe1874e5a282a9109d970b930c0413ed962b9234d01af5abc326bc11b76"
+checksum = "30a17d30d434968fa6e0fd5e8be2550220f9e7962522b4335260b2d54437a6a9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "qoqo_qasm"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "ndarray",
  "pyo3",
@@ -570,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "roqoqo"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5b17654263a25ef7954c6e18fefc24e8ca3244a2fa9cea30b690e3b8132161"
+checksum = "38fbc6b8a24cbd98bab6198b7ce4fc2657042cf8502f3ecb664bd13d037e0a1f"
 dependencies = [
  "bincode",
  "nalgebra",
@@ -651,24 +651,24 @@ dependencies = [
  "roqoqo-derive",
  "serde",
  "struqture",
- "syn 2.0.40",
+ "syn 2.0.48",
  "thiserror",
 ]
 
 [[package]]
 name = "roqoqo-derive"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21984a8ac947b1089226deb7ed9b33e860d78bae4335fee1609d7b34e61e7fd3"
+checksum = "a2cd3ab0d30f23bcf090dbea09602f183fbb668e0ca65c0feff1360572044524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "roqoqo-qasm"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "ndarray",
  "num-complex",
@@ -732,22 +732,22 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -798,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
 
 [[package]]
 name = "struqture"
@@ -839,7 +839,7 @@ dependencies = [
  "serde_json",
  "struqture",
  "struqture-py-macros",
- "syn 2.0.40",
+ "syn 2.0.48",
  "thiserror",
 ]
 
@@ -852,7 +852,7 @@ dependencies = [
  "num-complex",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.40"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fa70a4ee923979ffb522cacce59d34421ebdea5625e1073c4326ef9d2dd42e"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.12"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
+checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
 
 [[package]]
 name = "test-case"
@@ -901,7 +901,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -912,28 +912,28 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.48",
  "test-case-core",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/qoqo_qasm/Cargo.toml
+++ b/qoqo_qasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo_qasm"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -28,8 +28,8 @@ crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-qoqo = { version = "1.8", default-features = false }
-roqoqo = { version = "1.8", features = ["serialize"] }
+qoqo = { version = "1.9", default-features = false }
+roqoqo = { version = "1.9", features = ["serialize"] }
 roqoqo-qasm = { version = "0.9", path = "../roqoqo-qasm" }
 
 [dependencies.pyo3]

--- a/qoqo_qasm/pyproject.toml
+++ b/qoqo_qasm/pyproject.toml
@@ -2,7 +2,7 @@
 name = "qoqo_qasm"
 version = "0.9.4"
 dependencies = [
-  'qoqo>=1.8',
+  'qoqo>=1.9',
   'qoqo_calculator_pyo3>=1.1',
 ]
 license = {text="Apache-2.0 AND Apache-2.0 with LLVM-exception AND MIT AND Unicode-DFS-2016 AND BSD-2-Clause AND BSD-3-CLause"}

--- a/qoqo_qasm/pyproject.toml
+++ b/qoqo_qasm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qasm"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
   'qoqo>=1.8',
   'qoqo_calculator_pyo3>=1.1',

--- a/qoqo_qasm/qoqo_qasm/DEPENDENCIES
+++ b/qoqo_qasm/qoqo_qasm/DEPENDENCIES
@@ -2009,7 +2009,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-getrandom 0.2.11
+getrandom 0.2.12
 https://github.com/rust-random/getrandom
 by The Rand Project Developers
 A small cross-platform library for retrieving random data from system source
@@ -2222,7 +2222,7 @@ limitations under the License.
 ----------------------------------------------------
 LICENSE-MIT:
 
-Copyright 2018 Developers of the Rand project
+Copyright (c) 2018-2024 The rust-random Project Developers
 Copyright (c) 2014 The Rust Project Developers
 
 Permission is hereby granted, free of charge, to any
@@ -3188,7 +3188,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-inventory 0.3.13
+inventory 0.3.14
 https://github.com/dtolnay/inventory
 by David Tolnay <dtolnay@gmail.com>
 Typed distributed plugin registration
@@ -3857,7 +3857,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-libc 0.2.151
+libc 0.2.152
 https://github.com/rust-lang/libc
 by The Rust Project Developers
 Raw FFI bindings to platform libraries like libc.
@@ -7709,7 +7709,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-proc-macro2 1.0.70
+proc-macro2 1.0.76
 https://github.com/dtolnay/proc-macro2
 by David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>
 A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.
@@ -7923,7 +7923,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-pyo3 0.20.0
+pyo3 0.20.2
 https://github.com/pyo3/pyo3
 by PyO3 Project and Contributors <https://github.com/PyO3>
 Bindings to Python interpreter
@@ -8152,7 +8152,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-pyo3-build-config 0.20.0
+pyo3-build-config 0.20.2
 https://github.com/pyo3/pyo3
 by PyO3 Project and Contributors <https://github.com/PyO3>
 Build configuration for the PyO3 ecosystem
@@ -8381,7 +8381,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-pyo3-ffi 0.20.0
+pyo3-ffi 0.20.2
 https://github.com/pyo3/pyo3
 by PyO3 Project and Contributors <https://github.com/PyO3>
 Python-API bindings for the PyO3 ecosystem
@@ -8610,7 +8610,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-pyo3-macros 0.20.0
+pyo3-macros 0.20.2
 https://github.com/pyo3/pyo3
 by PyO3 Project and Contributors <https://github.com/PyO3>
 Proc macros for PyO3 package
@@ -8839,7 +8839,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-pyo3-macros-backend 0.20.0
+pyo3-macros-backend 0.20.2
 https://github.com/pyo3/pyo3
 by PyO3 Project and Contributors <https://github.com/PyO3>
 Code generation for PyO3 package
@@ -9068,7 +9068,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-qoqo 1.8.0
+qoqo 1.9.1
 https://github.com/HQSquantumsimulations/qoqo
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Quantum computing circuit toolkit. Python interface of roqoqo
@@ -9280,7 +9280,7 @@ LICENSE:
 
 
 ====================================================
-qoqo-macros 1.8.0
+qoqo-macros 1.9.1
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Macros for the qoqo crate
 License: Apache-2.0
@@ -9915,7 +9915,7 @@ LICENSE:
 
 
 ====================================================
-qoqo_qasm 0.9.3
+qoqo_qasm 0.9.4
 https://github.com/HQSquantumsimulations/qoqo_qasm
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Python interface of roqoqo_qasm by HQS Quantum Simulations
@@ -10127,7 +10127,7 @@ LICENSE:
 
 
 ====================================================
-quote 1.0.33
+quote 1.0.35
 https://github.com/dtolnay/quote
 by David Tolnay <dtolnay@gmail.com>
 Quasi-quoting macro quote!(...)
@@ -11537,7 +11537,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-roqoqo 1.8.0
+roqoqo 1.9.1
 https://github.com/HQSquantumsimulations/qoqo
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Rust Quantum Computing Toolkit by HQS
@@ -11749,7 +11749,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-derive 1.8.0
+roqoqo-derive 1.9.1
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Macros for the roqoqo crate
 License: Apache-2.0
@@ -11960,7 +11960,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-qasm 0.9.3
+roqoqo-qasm 0.9.4
 https://github.com/HQSquantumsimulations/qoqo_qasm
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QASM interface for roqoqo Rust quantum computing toolkit by HQS Quantum Simulations
@@ -13035,7 +13035,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde 1.0.193
+serde 1.0.195
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 A generic serialization/deserialization framework
@@ -13249,7 +13249,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde_derive 1.0.193
+serde_derive 1.0.195
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 Macros 1.1 implementation of #[derive(Serialize, Deserialize)]
@@ -13702,7 +13702,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde_json 1.0.108
+serde_json 1.0.111
 https://github.com/serde-rs/json
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 A JSON serialization file format
@@ -14128,7 +14128,7 @@ LICENSE:
 
 
 ====================================================
-smallvec 1.11.2
+smallvec 1.12.0
 https://github.com/servo/rust-smallvec
 by The Servo Project Developers
 'Small vector' optimization: store up to a small number of items on the stack
@@ -15036,7 +15036,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-syn 2.0.40
+syn 2.0.48
 https://github.com/dtolnay/syn
 by David Tolnay <dtolnay@gmail.com>
 Parser for Rust source code
@@ -15250,7 +15250,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-target-lexicon 0.12.12
+target-lexicon 0.12.13
 https://github.com/bytecodealliance/target-lexicon
 by Dan Gohman <sunfish@mozilla.com>
 Targeting utilities for compilers and related tools
@@ -15577,7 +15577,7 @@ SOFTWARE.
 
 
 ====================================================
-thiserror 1.0.50
+thiserror 1.0.56
 https://github.com/dtolnay/thiserror
 by David Tolnay <dtolnay@gmail.com>
 derive(Error)
@@ -15791,7 +15791,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-thiserror-impl 1.0.50
+thiserror-impl 1.0.56
 https://github.com/dtolnay/thiserror
 by David Tolnay <dtolnay@gmail.com>
 Implementation detail of the `thiserror` crate

--- a/roqoqo-qasm/Cargo.toml
+++ b/roqoqo-qasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo-qasm"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -19,7 +19,7 @@ doctest = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-roqoqo = { version = "1.8", features = ["serialize"] }
+roqoqo = { version = "1.9", features = ["serialize"] }
 qoqo_calculator = { version = "1.1" }
 ndarray = "0.15"
 pest = { version = "2.5", optional = true }

--- a/roqoqo-qasm/src/grammars/qasm2_0.pest
+++ b/roqoqo-qasm/src/grammars/qasm2_0.pest
@@ -1,5 +1,6 @@
 openqasm = _{ "OPENQASM" ~ real ~ ";" ~ NEWLINE ~ maincontent }
-maincontent = _{ ((q_decl | c_decl | comment | reset | measurement | gate) ~ NEWLINE | NEWLINE)* }
+maincontent = _{ ((q_decl | c_decl | gate_def | comment | reset | measurement | gate) ~ NEWLINE | NEWLINE)* }
+gate_def = { "gate" ~ (!NEWLINE ~ ANY)* }
 q_decl = { "qreg" ~ id ~ "[" ~ integer ~ "]" ~ ";" }
 c_decl = { "creg" ~ id ~ "[" ~ integer ~ "]" ~ ";" }
 gate = { id ~ parameter_list? ~ qubit_list ~ ";" }

--- a/roqoqo-qasm/tests/gate_defs.qasm
+++ b/roqoqo-qasm/tests/gate_defs.qasm
@@ -1,0 +1,13 @@
+OPENQASM 2.0;
+
+gate u3(theta,phi,lambda) q { U(theta,phi,lambda) q; }
+gate u2(phi,lambda) q { U(pi/2,phi,lambda) q; }
+gate u1(lambda) q { U(0,0,lambda) q; }
+gate rx(theta) a { u3(theta,-pi/2,pi/2) a; }
+gate ry(theta) a { u3(theta,0,0) a; }
+gate rz(phi) a { u1(phi) a; }
+gate cx c,t { CX c,t; }
+gate h a { u2(0,pi) a; }
+qreg q[1];
+
+h q[0];

--- a/roqoqo-qasm/tests/integration/parser.rs
+++ b/roqoqo-qasm/tests/integration/parser.rs
@@ -150,3 +150,15 @@ fn test_comments() {
 
     assert_eq!(circuit_from_file, circuit_qoqo);
 }
+
+#[test]
+fn test_gate_definitions() {
+    let file = File::open(std::env::current_dir().unwrap().join("tests/gate_defs.qasm")).unwrap();
+
+    let circuit_from_file = file_to_circuit(file).unwrap();
+
+    let mut circuit_qoqo = Circuit::new();
+    circuit_qoqo += Hadamard::new(0);
+
+    assert_eq!(circuit_from_file, circuit_qoqo);
+}

--- a/roqoqo-qasm/tests/integration/parser.rs
+++ b/roqoqo-qasm/tests/integration/parser.rs
@@ -153,7 +153,12 @@ fn test_comments() {
 
 #[test]
 fn test_gate_definitions() {
-    let file = File::open(std::env::current_dir().unwrap().join("tests/gate_defs.qasm")).unwrap();
+    let file = File::open(
+        std::env::current_dir()
+            .unwrap()
+            .join("tests/gate_defs.qasm"),
+    )
+    .unwrap();
 
     let circuit_from_file = file_to_circuit(file).unwrap();
 


### PR DESCRIPTION
This adds supports for QASM import of files that contain a gate definition.

We don't fully support them yet, as qoqo right now is not capable of instantiating custom gates. What this does, is it skips those definitions all-together. This way, a qoqo circuit whose QASM has been created via `QasmBackend.circuit_to_qasm_str()` (or `QasmBackend.circuit_to_qasm_file()`) can be imported correctly via `QasmBackend.qasm_str_to_circuit()` (or `QasmBackend.qasm_file_to_circuit()`).