### PR TITLE
QASM Parsing: Include Line Skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 This changelog track changes to the qoqo qasm project starting at version 0.5.0
 
+### 0.9.5
+
+* Updated QASM parsing feature to skip include files lines
+
 ### 0.9.4
 
 * Updated to qoqo 1.9
-* Updated parsing feature to skip QASM gate definitions
+* Updated QASM parsing feature to skip gate definitions
 
 ### 0.9.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "ea31d69bda4949c1c1562c1e6f042a1caefac98cdc8a298260a2ff41c1e2d42b"
 
 [[package]]
 name = "cfg-if"
@@ -141,9 +141,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -157,15 +157,15 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "inventory"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8573b2b1fb643a372c73b23f4da5f888677feef3305146d68a539250a9bccc7"
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -178,9 +178,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libm"
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
  "serde",
@@ -357,9 +357,9 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pest"
-version = "2.7.6"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f200d8d83c44a45b21764d1916299752ca035d15ecd46faca3e9a2a2bf6ad06"
+checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
 dependencies = [
  "memchr",
  "thiserror",
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.6"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd6ab1236bbdb3a49027e920e693192ebfe8913f6d60e294de57463a493cfde"
+checksum = "22e1288dbd7786462961e69bfd4df7848c1e37e8b74303dbdab82c3a9cdd2809"
 dependencies = [
  "pest",
  "pest_generator",
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.6"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a31940305ffc96863a735bef7c7994a00b325a7138fdbc5bda0f1a0476d3275"
+checksum = "1381c29a877c6d34b8c176e734f35d7f7f5b3adaefe940cb4d1bb7af94678e2e"
 dependencies = [
  "pest",
  "pest_meta",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.6"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ff62f5259e53b78d1af898941cdcdccfae7385cf7d793a6e55de5d05bb4b7d"
+checksum = "d0934d6907f148c22a3acbda520c7eed243ad7487a30f51f6ce52b58b7077a8a"
 dependencies = [
  "once_cell",
  "pest",
@@ -420,9 +420,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "qoqo_qasm"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "ndarray",
  "pyo3",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "roqoqo-qasm"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "ndarray",
  "num-complex",
@@ -732,18 +732,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -798,15 +798,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "struqture"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b3b736950a60ff795d13e8e89d75fde0bd9510ea420f06c0649791f6fe3194"
+checksum = "be0c8e01ccb1eb5704756651126b09a0eb276fe3d018e87f6490773cefb38359"
 dependencies = [
  "itertools",
  "ndarray",
@@ -821,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "struqture-py"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "592b7232573f8d40afc2f55d6829a45a31e0bb3d371e4930f4470400fa62d352"
+checksum = "09b138454a27864ea7ca9a22eaf0351270c78cb329961e5d46395cc9bcac31b3"
 dependencies = [
  "bincode",
  "num-complex",
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "struqture-py-macros"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3abb53a16639536f41a39adf11db2ed2f318217de87fc4f47c1caf771d7576"
+checksum = "9274be85d19e94e55fba30b59ef862d2b11778b099a61449cb381c8965644c79"
 dependencies = [
  "num-complex",
  "proc-macro2",
@@ -990,9 +990,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wide"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68938b57b33da363195412cfc5fc37c9ed49aa9cfe2156fde64b8d2c9498242"
+checksum = "89beec544f246e679fc25490e3f8e08003bc4bf612068f325120dad4cea02c1c"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/qoqo_qasm/Cargo.toml
+++ b/qoqo_qasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo_qasm"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/qoqo_qasm/pyproject.toml
+++ b/qoqo_qasm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qasm"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
   'qoqo>=1.9',
   'qoqo_calculator_pyo3>=1.1',

--- a/qoqo_qasm/qoqo_qasm/DEPENDENCIES
+++ b/qoqo_qasm/qoqo_qasm/DEPENDENCIES
@@ -727,7 +727,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-bytemuck 1.14.0
+bytemuck 1.14.2
 https://github.com/Lokathor/bytemuck
 by Lokathor <zefria@gmail.com>
 A crate for mucking around with piles of bytes.
@@ -2733,8 +2733,8 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-indexmap 2.1.0
-https://github.com/bluss/indexmap
+indexmap 2.2.2
+https://github.com/indexmap-rs/indexmap
 by 
 A hash table with consistent order and fast iteration.
 License: Apache-2.0 OR MIT
@@ -3188,7 +3188,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-inventory 0.3.14
+inventory 0.3.15
 https://github.com/dtolnay/inventory
 by David Tolnay <dtolnay@gmail.com>
 Typed distributed plugin registration
@@ -3402,7 +3402,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-itertools 0.12.0
+itertools 0.12.1
 https://github.com/rust-itertools/itertools
 by bluss
 Extra iterator adaptors, iterator methods, free functions, and macros.
@@ -3857,7 +3857,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-libc 0.2.152
+libc 0.2.153
 https://github.com/rust-lang/libc
 by The Rust Project Developers
 Raw FFI bindings to platform libraries like libc.
@@ -5292,7 +5292,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-num-complex 0.4.4
+num-complex 0.4.5
 https://github.com/rust-num/num-complex
 by The Rust Project Developers
 Complex numbers implementation for Rust
@@ -7709,7 +7709,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-proc-macro2 1.0.76
+proc-macro2 1.0.78
 https://github.com/dtolnay/proc-macro2
 by David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>
 A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.
@@ -9915,7 +9915,7 @@ LICENSE:
 
 
 ====================================================
-qoqo_qasm 0.9.4
+qoqo_qasm 0.9.5
 https://github.com/HQSquantumsimulations/qoqo_qasm
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Python interface of roqoqo_qasm by HQS Quantum Simulations
@@ -11960,7 +11960,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-qasm 0.9.4
+roqoqo-qasm 0.9.5
 https://github.com/HQSquantumsimulations/qoqo_qasm
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QASM interface for roqoqo Rust quantum computing toolkit by HQS Quantum Simulations
@@ -13035,7 +13035,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde 1.0.195
+serde 1.0.196
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 A generic serialization/deserialization framework
@@ -13249,7 +13249,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde_derive 1.0.195
+serde_derive 1.0.196
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 Macros 1.1 implementation of #[derive(Serialize, Deserialize)]
@@ -13702,7 +13702,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde_json 1.0.111
+serde_json 1.0.113
 https://github.com/serde-rs/json
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 A JSON serialization file format
@@ -14128,7 +14128,7 @@ LICENSE:
 
 
 ====================================================
-smallvec 1.12.0
+smallvec 1.13.1
 https://github.com/servo/rust-smallvec
 by The Servo Project Developers
 'Small vector' optimization: store up to a small number of items on the stack
@@ -14369,7 +14369,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-struqture 1.5.2
+struqture 1.6.0
 by HQS Quantum Simulations <info@quantumsimulations.de>
 HQS tool for representing operators, Hamiltonians and open systems.
 License: Apache-2.0
@@ -14580,13 +14580,13 @@ LICENSE:
 
 
 ====================================================
-struqture-py 1.5.2
+struqture-py 1.6.0
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Python interface of struqture, the HQS tool for representing operators, Hamiltonians and open systems.
 License: Apache-2.0
 
 ====================================================
-struqture-py-macros 1.5.2
+struqture-py-macros 1.6.0
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Macros for struqture-py crate.
 License: Apache-2.0
@@ -17688,7 +17688,7 @@ Software.
 
 
 ====================================================
-wide 0.7.13
+wide 0.7.15
 https://github.com/Lokathor/wide
 by Lokathor <zefria@gmail.com>
 A crate to help you go wide.

--- a/qoqo_qasm/tests/integration/main.rs
+++ b/qoqo_qasm/tests/integration/main.rs
@@ -12,14 +12,10 @@
 
 #[cfg(test)]
 mod backend;
-pub use backend::*;
 
 #[cfg(test)]
 mod interface;
-pub use interface::*;
 
 #[cfg(test)]
 #[cfg(feature = "unstable_qasm_import")]
 mod parser;
-#[cfg(feature = "unstable_qasm_import")]
-pub use parser::*;

--- a/roqoqo-qasm/Cargo.toml
+++ b/roqoqo-qasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo-qasm"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/roqoqo-qasm/src/grammars/qasm2_0.pest
+++ b/roqoqo-qasm/src/grammars/qasm2_0.pest
@@ -1,10 +1,11 @@
 openqasm = _{ "OPENQASM" ~ real ~ ";" ~ NEWLINE ~ maincontent }
-maincontent = _{ ((q_decl | c_decl | gate_def | comment | reset | measurement | gate) ~ NEWLINE | NEWLINE)* }
+maincontent = _{ ((q_decl | c_decl | gate_def | include | comment | reset | measurement | gate) ~ NEWLINE | NEWLINE)* }
 gate_def = { "gate" ~ (!NEWLINE ~ ANY)* }
 q_decl = { "qreg" ~ id ~ "[" ~ integer ~ "]" ~ ";" }
 c_decl = { "creg" ~ id ~ "[" ~ integer ~ "]" ~ ";" }
 gate = { id ~ parameter_list? ~ qubit_list ~ ";" }
 measurement = { "measure" ~ argument ~ "->" ~ argument ~ ";" }
+include = { "include" ~ (!NEWLINE ~ ANY)* }
 comment = { "//" ~ (!NEWLINE ~ ANY)* }
 reset = { "reset" ~ argument ~ ";" }
 

--- a/roqoqo-qasm/tests/acceptance/main.rs
+++ b/roqoqo-qasm/tests/acceptance/main.rs
@@ -12,4 +12,3 @@
 
 #[cfg(test)]
 mod test_acceptance;
-pub use test_acceptance::*;

--- a/roqoqo-qasm/tests/include.qasm
+++ b/roqoqo-qasm/tests/include.qasm
@@ -1,0 +1,13 @@
+OPENQASM 2.0;
+include "custom_lib.inc";
+include "other_lib.inc";
+
+creg c[2];
+qreg q[3];
+
+x q[0];
+h q[1];
+rx(2.3) q[2];
+cx q[0],q[1];
+
+measure q[0] -> c[0];

--- a/roqoqo-qasm/tests/integration/main.rs
+++ b/roqoqo-qasm/tests/integration/main.rs
@@ -12,18 +12,13 @@
 
 #[cfg(test)]
 mod backend;
-pub use backend::*;
 
 #[cfg(test)]
 mod interface;
-pub use interface::*;
 
 #[cfg(test)]
 #[cfg(feature = "unstable_qasm_import")]
 mod parser;
-#[cfg(feature = "unstable_qasm_import")]
-pub use parser::*;
 
 #[cfg(test)]
 mod variable_gatherer;
-pub use variable_gatherer::*;

--- a/roqoqo-qasm/tests/integration/parser.rs
+++ b/roqoqo-qasm/tests/integration/parser.rs
@@ -167,3 +167,20 @@ fn test_gate_definitions() {
 
     assert_eq!(circuit_from_file, circuit_qoqo);
 }
+
+#[test]
+fn test_include_line_skip() {
+    let file = File::open(std::env::current_dir().unwrap().join("tests/include.qasm")).unwrap();
+
+    let circuit_from_file = file_to_circuit(file).unwrap();
+
+    let mut circuit_qoqo = Circuit::new();
+    circuit_qoqo += DefinitionBit::new("c".into(), 2, true);
+    circuit_qoqo += PauliX::new(0);
+    circuit_qoqo += Hadamard::new(1);
+    circuit_qoqo += RotateX::new(2, 2.3.into());
+    circuit_qoqo += CNOT::new(0, 1);
+    circuit_qoqo += MeasureQubit::new(0, "c".into(), 0);
+
+    assert_eq!(circuit_from_file, circuit_qoqo);
+}


### PR DESCRIPTION
Adds parsing support for QASM files containing `include` instructions, skipping the operation. 