### PR TITLE
PragmaSleep 2.0 Redefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This changelog track changes to the qoqo qasm project starting at version 0.5.0
 
+### 0.9.6
+
+* Modified QASM 2.0 `PragmaSleep` gate definition
+
 ### 0.9.5
 
 * Updated QASM parsing feature to skip include files lines

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.14.2"
+version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea31d69bda4949c1c1562c1e6f042a1caefac98cdc8a298260a2ff41c1e2d42b"
+checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
 
 [[package]]
 name = "cfg-if"
@@ -276,11 +276,10 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
@@ -297,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -556,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "qoqo_qasm"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "ndarray",
  "pyo3",
@@ -668,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "roqoqo-qasm"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "ndarray",
  "num-complex",

--- a/qoqo_qasm/Cargo.toml
+++ b/qoqo_qasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo_qasm"
-version = "0.9.5"
+version = "0.9.6"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/qoqo_qasm/pyproject.toml
+++ b/qoqo_qasm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qasm"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
   'qoqo>=1.9',
   'qoqo_calculator_pyo3>=1.1',

--- a/qoqo_qasm/qoqo_qasm/DEPENDENCIES
+++ b/qoqo_qasm/qoqo_qasm/DEPENDENCIES
@@ -727,7 +727,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-bytemuck 1.14.2
+bytemuck 1.14.3
 https://github.com/Lokathor/bytemuck
 by Lokathor <zefria@gmail.com>
 A crate for mucking around with piles of bytes.
@@ -5533,7 +5533,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-num-integer 0.1.45
+num-integer 0.1.46
 https://github.com/rust-num/num-integer
 by The Rust Project Developers
 Integer traits and functions
@@ -6015,7 +6015,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-num-traits 0.2.17
+num-traits 0.2.18
 https://github.com/rust-num/num-traits
 by The Rust Project Developers
 Numeric traits for generic mathematics
@@ -9915,7 +9915,7 @@ LICENSE:
 
 
 ====================================================
-qoqo_qasm 0.9.5
+qoqo_qasm 0.9.6
 https://github.com/HQSquantumsimulations/qoqo_qasm
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Python interface of roqoqo_qasm by HQS Quantum Simulations
@@ -11960,7 +11960,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-qasm 0.9.5
+roqoqo-qasm 0.9.6
 https://github.com/HQSquantumsimulations/qoqo_qasm
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QASM interface for roqoqo Rust quantum computing toolkit by HQS Quantum Simulations

--- a/qoqo_qasm/tests/integration/interface.rs
+++ b/qoqo_qasm/tests/integration/interface.rs
@@ -200,7 +200,6 @@ fn test_qasm_call_operation_error_2_3(operation: Operation, converted_3: &str) {
     })
 }
 
-#[test_case(Operation::from(PragmaSleep::new(vec![0,1], CalculatorFloat::from(0.3))), "", "pragma roqoqo PragmaSleep [0, 1] 3e-1;"; "PragmaSleep")]
 #[test_case(Operation::from(PragmaStopDecompositionBlock::new(vec![0,1])), "", "pragma roqoqo PragmaStopDecompositionBlock [0, 1];"; "PragmaStopDecompositionBlock")]
 #[test_case(Operation::from(PragmaStopParallelBlock::new(vec![], CalculatorFloat::from(0.0))), "", "pragma roqoqo PragmaStopParallelBlock [] 0e0;"; "PragmaStopParallelBlock")]
 #[test_case(Operation::from(PragmaSetNumberOfMeasurements::new(20, "ro".to_string())), "", "pragma roqoqo PragmaSetNumberOfMeasurements 20 ro;"; "PragmaSetNumberOfMeasurements")]
@@ -237,12 +236,14 @@ fn test_call_operation_different_2_roqoqo_3(
     })
 }
 
-#[test_case(Operation::from(PragmaLoop::new(2.0.into(), Circuit::new() + PauliX::new(0))), "pragma roqoqo PragmaLoop 2e0 PauliX(PauliX { qubit: 0 })\n;", "for uint i in [0:2] {\n    x q[0];\n}", "x q[0];\nx q[0];\n"; "PragmaLoop")]
+#[test_case(Operation::from(PragmaLoop::new(2.0.into(), Circuit::new() + PauliX::new(0))), "pragma roqoqo PragmaLoop 2e0 PauliX(PauliX { qubit: 0 })\n;", "for uint i in [0:2] {\n    x q[0];\n}", "x q[0];\nx q[0];\n", "x q[0];\nx q[0];\n"; "PragmaLoop")]
+#[test_case(Operation::from(PragmaSleep::new(vec![0,1], CalculatorFloat::from(0.3))), "pragma roqoqo PragmaSleep [0, 1] 3e-1;", "", "", "pragmasleep(3e-1) q[0];\npragmasleep(3e-1) q[1];"; "PragmaSleep")]
 fn test_call_operation_error_different_all(
     operation: Operation,
     converted_3_roqoqo: &str,
     converted_3_vanilla: &str,
-    converted_2_converted_3_braket: &str,
+    converted_3_braket: &str,
+    converted_2: &str,
 ) {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
@@ -250,11 +251,11 @@ fn test_call_operation_error_different_all(
 
         assert_eq!(
             qasm_call_operation(new_op.as_ref(py), "q", "3.0Braket").unwrap(),
-            converted_2_converted_3_braket.to_string()
+            converted_3_braket.to_string()
         );
         assert_eq!(
             qasm_call_operation(new_op.as_ref(py), "q", "2.0").unwrap(),
-            converted_2_converted_3_braket.to_string()
+            converted_2.to_string()
         );
 
         assert_eq!(

--- a/roqoqo-qasm/Cargo.toml
+++ b/roqoqo-qasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo-qasm"
-version = "0.9.5"
+version = "0.9.6"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/roqoqo-qasm/src/interface.rs
+++ b/roqoqo-qasm/src/interface.rs
@@ -982,7 +982,7 @@ pub fn call_operation(
                 for (ind, qbt) in op.qubits().iter().enumerate() {
                     output_string.push_str(
                         format!(
-                            "delay({}) {}[{}];",
+                            "pragmasleep({}) {}[{}];",
                             op.sleep_time(),
                             qubit_register_name,
                             qbt
@@ -1300,7 +1300,7 @@ pub fn gate_definition(
             }),
         },
         Operation::PragmaSleep(_) => Ok(String::from(
-            "opaque delay(param) a;"
+            "opaque pragmasleep(param) a;"
         )),
         _ => {
             if NO_DEFINITION_REQUIRED_OPERATIONS.contains(&operation.hqslang()) || ALLOWED_OPERATIONS.contains(&operation.hqslang()) {

--- a/roqoqo-qasm/src/interface.rs
+++ b/roqoqo-qasm/src/interface.rs
@@ -977,6 +977,24 @@ pub fn call_operation(
                 op.qubits(),
                 op.sleep_time()
             )),
+            QasmVersion::V2point0 => {
+                let mut output_string = "".to_string();
+                for (ind, qbt) in op.qubits().iter().enumerate() {
+                    output_string.push_str(
+                        format!(
+                            "delay({}) {}[{}];",
+                            op.sleep_time(),
+                            qubit_register_name,
+                            qbt
+                        )
+                        .as_str(),
+                    );
+                    if ind != op.qubits().len() - 1 {
+                        output_string.push('\n');
+                    }
+                }
+                Ok(output_string)
+            }
             _ => {
                 if ALLOWED_OPERATIONS.contains(&operation.hqslang()) {
                     Ok("".to_string())
@@ -1281,6 +1299,9 @@ pub fn gate_definition(
                 hqslang: operation.hqslang(),
             }),
         },
+        Operation::PragmaSleep(_) => Ok(String::from(
+            "opaque delay(param) a;"
+        )),
         _ => {
             if NO_DEFINITION_REQUIRED_OPERATIONS.contains(&operation.hqslang()) || ALLOWED_OPERATIONS.contains(&operation.hqslang()) {
                 Ok("".to_string())

--- a/roqoqo-qasm/tests/integration/interface.rs
+++ b/roqoqo-qasm/tests/integration/interface.rs
@@ -150,7 +150,6 @@ fn test_call_operation_different_2_3(operation: Operation, converted_2: &str, co
 }
 
 /// Test that all operations return the correct String: 2.0 vs. 3.0 differences (Roqoqo dialect)
-#[test_case(Operation::from(PragmaSleep::new(vec![0,1], CalculatorFloat::from(0.3))), "", "pragma roqoqo PragmaSleep [0, 1] 3e-1;"; "PragmaSleep")]
 #[test_case(Operation::from(PragmaStopDecompositionBlock::new(vec![0,1])), "", "pragma roqoqo PragmaStopDecompositionBlock [0, 1];"; "PragmaStopDecompositionBlock")]
 #[test_case(Operation::from(PragmaStopParallelBlock::new(vec![], CalculatorFloat::from(0.0))), "", "pragma roqoqo PragmaStopParallelBlock [] 0e0;"; "PragmaStopParallelBlock")]
 #[test_case(Operation::from(PragmaSetNumberOfMeasurements::new(20, "ro".to_string())), "", "pragma roqoqo PragmaSetNumberOfMeasurements 20 ro;"; "PragmaSetNumberOfMeasurements")]
@@ -476,7 +475,7 @@ fn test_call_operation_error_2_3(operation: Operation, converted_3: &str) {
 #[test_case(Operation::from(SpinInteraction::new(0, 1, CalculatorFloat::from(0.3), CalculatorFloat::from(0.3), CalculatorFloat::from(0.3))), "gate spinint(xc,yc,zc) a,b { rz(-pi/2) a; rz(pi) b; ry(pi/2) b; u2(0,pi) b; cx a,b; u2(0,pi) b; ry(-2*xc) a; rx(pi) a; ry(-pi/2) b; rz(2*zc-pi/2) b; u2(0,pi) b; cx a,b; u2(0,pi) b; rz(pi) a; ry(2*yc+pi) a; rz(pi) b; ry(pi/2) b; u2(0,pi) b; cx a,b; u2(0,pi) b; rz(-pi/2) b; rx(-pi/2) b; }"; "SpinInteraction")]
 #[test_case(Operation::from(PhaseShiftedControlledZ::new(0, 1, CalculatorFloat::from(0.2))), "gate pscz(phi) a,b { rz(pi/2) a; rz(pi/2) b; ry(pi/2) b; cx a,b; rx(-pi/2) b; rz(-pi/2) a; ry(-pi/2) b; rz(phi) a; rz(phi) b; }"; "PhaseShiftedControlledZ")]
 #[test_case(Operation::from(PhaseShiftedControlledPhase::new(0, 1, CalculatorFloat::from(0.2), CalculatorFloat::from(0.2))), "gate pscp(theta,phi) a,b { rz(theta/2) a; rz(theta/2) b; cx a,b; rz(-theta/2) b; cx a,b; rz(phi) a; rz(phi) b; }"; "PhaseShiftedControlledPhase")]
-#[test_case(Operation::from(PragmaSleep::new(vec![0,1], CalculatorFloat::from(0.3))), ""; "PragmaSleep")]
+#[test_case(Operation::from(PragmaSleep::new(vec![0,1], CalculatorFloat::from(0.3))), "opaque delay(param) a;"; "PragmaSleep")]
 #[test_case(Operation::from(PragmaGlobalPhase::new(CalculatorFloat::from(0.3))), ""; "PragmaGlobalPhase")]
 #[test_case(Operation::from(PragmaStopDecompositionBlock::new(vec![0,1])), ""; "PragmaStopDecompositionBlock")]
 #[test_case(Operation::from(PragmaStopParallelBlock::new(vec![], CalculatorFloat::from(0.0))), ""; "PragmaStopParallelBlock")]
@@ -684,6 +683,67 @@ fn test_pragma_loop() {
             &mut None
         ),
         Err(error)
+    );
+}
+
+#[test]
+fn test_pragma_sleep() {
+    let p_sleep_single = PragmaSleep::new(vec![5], CalculatorFloat::from(0.05));
+    let p_sleep_double = PragmaSleep::new(vec![0, 1], CalculatorFloat::from(1.0));
+
+    assert_eq!(
+        call_operation(
+            &Operation::from(p_sleep_single.clone()),
+            "q",
+            QasmVersion::V2point0,
+            &mut None
+        )
+        .unwrap(),
+        "delay(5e-2) q[5];"
+    );
+
+    assert_eq!(
+        call_operation(
+            &Operation::from(p_sleep_double.clone()),
+            "q",
+            QasmVersion::V2point0,
+            &mut None
+        )
+        .unwrap(),
+        "delay(1e0) q[0];\ndelay(1e0) q[1];"
+    );
+
+    assert_eq!(
+        call_operation(
+            &Operation::from(p_sleep_double.clone()),
+            "q",
+            QasmVersion::V3point0(Qasm3Dialect::Roqoqo),
+            &mut None
+        )
+        .unwrap(),
+        "pragma roqoqo PragmaSleep [0, 1] 1e0;"
+    );
+
+    assert_eq!(
+        call_operation(
+            &Operation::from(p_sleep_double.clone()),
+            "q",
+            QasmVersion::V3point0(Qasm3Dialect::Braket),
+            &mut None
+        )
+        .unwrap(),
+        ""
+    );
+
+    assert_eq!(
+        call_operation(
+            &Operation::from(p_sleep_double.clone()),
+            "q",
+            QasmVersion::V3point0(Qasm3Dialect::Vanilla),
+            &mut None
+        )
+        .unwrap(),
+        ""
     );
 }
 

--- a/roqoqo-qasm/tests/integration/interface.rs
+++ b/roqoqo-qasm/tests/integration/interface.rs
@@ -475,7 +475,7 @@ fn test_call_operation_error_2_3(operation: Operation, converted_3: &str) {
 #[test_case(Operation::from(SpinInteraction::new(0, 1, CalculatorFloat::from(0.3), CalculatorFloat::from(0.3), CalculatorFloat::from(0.3))), "gate spinint(xc,yc,zc) a,b { rz(-pi/2) a; rz(pi) b; ry(pi/2) b; u2(0,pi) b; cx a,b; u2(0,pi) b; ry(-2*xc) a; rx(pi) a; ry(-pi/2) b; rz(2*zc-pi/2) b; u2(0,pi) b; cx a,b; u2(0,pi) b; rz(pi) a; ry(2*yc+pi) a; rz(pi) b; ry(pi/2) b; u2(0,pi) b; cx a,b; u2(0,pi) b; rz(-pi/2) b; rx(-pi/2) b; }"; "SpinInteraction")]
 #[test_case(Operation::from(PhaseShiftedControlledZ::new(0, 1, CalculatorFloat::from(0.2))), "gate pscz(phi) a,b { rz(pi/2) a; rz(pi/2) b; ry(pi/2) b; cx a,b; rx(-pi/2) b; rz(-pi/2) a; ry(-pi/2) b; rz(phi) a; rz(phi) b; }"; "PhaseShiftedControlledZ")]
 #[test_case(Operation::from(PhaseShiftedControlledPhase::new(0, 1, CalculatorFloat::from(0.2), CalculatorFloat::from(0.2))), "gate pscp(theta,phi) a,b { rz(theta/2) a; rz(theta/2) b; cx a,b; rz(-theta/2) b; cx a,b; rz(phi) a; rz(phi) b; }"; "PhaseShiftedControlledPhase")]
-#[test_case(Operation::from(PragmaSleep::new(vec![0,1], CalculatorFloat::from(0.3))), "opaque delay(param) a;"; "PragmaSleep")]
+#[test_case(Operation::from(PragmaSleep::new(vec![0,1], CalculatorFloat::from(0.3))), "opaque pragmasleep(param) a;"; "PragmaSleep")]
 #[test_case(Operation::from(PragmaGlobalPhase::new(CalculatorFloat::from(0.3))), ""; "PragmaGlobalPhase")]
 #[test_case(Operation::from(PragmaStopDecompositionBlock::new(vec![0,1])), ""; "PragmaStopDecompositionBlock")]
 #[test_case(Operation::from(PragmaStopParallelBlock::new(vec![], CalculatorFloat::from(0.0))), ""; "PragmaStopParallelBlock")]
@@ -699,7 +699,7 @@ fn test_pragma_sleep() {
             &mut None
         )
         .unwrap(),
-        "delay(5e-2) q[5];"
+        "pragmasleep(5e-2) q[5];"
     );
 
     assert_eq!(
@@ -710,7 +710,7 @@ fn test_pragma_sleep() {
             &mut None
         )
         .unwrap(),
-        "delay(1e0) q[0];\ndelay(1e0) q[1];"
+        "pragmasleep(1e0) q[0];\npragmasleep(1e0) q[1];"
     );
 
     assert_eq!(


### PR DESCRIPTION
This makes use of the `opaque` keyword for the PragmaSleep operation, allowing OpenQASM 2.0 support.